### PR TITLE
clean simlab node shutdown

### DIFF
--- a/simlab/cartesian_ruckig.py
+++ b/simlab/cartesian_ruckig.py
@@ -98,3 +98,10 @@ class VehicleCartesianRuckig:
             self.active = False
 
         return pos, vel, acc, res
+
+    def close(self):
+        self.active = False
+        self.out = None
+        self.inp = None
+        self.otg = None
+        self.rclpy_node = None

--- a/simlab/collision_contact.py
+++ b/simlab/collision_contact.py
@@ -7,6 +7,7 @@ from tf2_ros import Buffer, TransformListener
 from visualization_msgs.msg import Marker
 from simlab.mesh_utils import make_marker, color, collect_env_meshes
 from simlab.fcl_checker import FCLWorld
+from simlab.shutdown import install_signal_shutdown_handler, shutdown_node, spin_until_shutdown
 
 
 class CollisionNode(Node):
@@ -36,6 +37,8 @@ class CollisionNode(Node):
         self.timer = self.create_timer(0.05, self.tick)
 
     def tick(self):
+        if not rclpy.ok():
+            return
         ok = self.world.update_from_tf(self.tf_buf, rclpy.time.Time())
         if not ok:
             return
@@ -44,7 +47,12 @@ class CollisionNode(Node):
         clear = Marker()
         clear.header.frame_id = 'world'
         clear.action = Marker.DELETEALL
-        self.contact_pub.publish(clear)
+        try:
+            self.contact_pub.publish(clear)
+        except Exception:
+            if rclpy.ok():
+                raise
+            return
 
         # 1. collision, one marker per robot link vs env link
         pairs = self.world.robot_env_contacts_one_point_per_pair()
@@ -55,7 +63,12 @@ class CollisionNode(Node):
             m = make_marker('contact', idx, 'world', CONTACT_MARKER_SIZE, p_world, red)
             m.lifetime.sec = 0
             m.lifetime.nanosec = int(0.1 * 1e9)
-            self.contact_pub.publish(m)
+            try:
+                self.contact_pub.publish(m)
+            except Exception:
+                if rclpy.ok():
+                    raise
+                return
 
         # 2. global clearance identical intent, now with nearest points enabled
         try:
@@ -72,15 +85,23 @@ class CollisionNode(Node):
                 # mr.lifetime.nanosec = int(0.1 * 1e9)
                 me.lifetime.nanosec = int(0.1 * 1e9)
                 # self.contact_pub.publish(mr)
-                self.contact_pub.publish(me)
+                try:
+                    self.contact_pub.publish(me)
+                except Exception:
+                    if rclpy.ok():
+                        raise
         except Exception as e:
-            self.get_logger().warn(f'clearance failed, {e}')
+            if rclpy.ok():
+                self.get_logger().warn(f'clearance failed, {e}')
 
 def main():
     rclpy.init()
+    install_signal_shutdown_handler()
     node = CollisionNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+    try:
+        spin_until_shutdown(node)
+    finally:
+        shutdown_node(node)
 
 if __name__ == '__main__':
     main()

--- a/simlab/env_obstacles.py
+++ b/simlab/env_obstacles.py
@@ -18,6 +18,7 @@ import os
 import numpy as np
 import rclpy
 from rclpy.node import Node
+from simlab.shutdown import install_signal_shutdown_handler, shutdown_node, spin_until_shutdown
 
 
 class EnvObstacleNode(Node):
@@ -36,9 +37,12 @@ class EnvObstacleNode(Node):
 
 def main():
     rclpy.init()
+    install_signal_shutdown_handler()
     node = EnvObstacleNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+    try:
+        spin_until_shutdown(node)
+    finally:
+        shutdown_node(node)
 
 
 if __name__ == "__main__":

--- a/simlab/interactive_control.py
+++ b/simlab/interactive_control.py
@@ -18,6 +18,7 @@ import time
 
 import rclpy
 from rclpy.node import Node
+from simlab.shutdown import install_signal_shutdown_handler, shutdown_node, spin_until_shutdown
 from rviz_2d_overlay_msgs.msg import OverlayText
 from simlab.uvms_backend import UVMSBackendCore
 from visualization_msgs.msg import InteractiveMarkerControl, InteractiveMarkerFeedback
@@ -535,14 +536,12 @@ class InteractiveControlsNode(Node):
 
 def main(args=None):
     rclpy.init(args=args)
+    install_signal_shutdown_handler()
     node = InteractiveControlsNode()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
-        pass
+        spin_until_shutdown(node)
     finally:
-        node.destroy_node()
-        rclpy.shutdown()
+        shutdown_node(node)
 
 if __name__ == '__main__':
     main()

--- a/simlab/interactive_control.py
+++ b/simlab/interactive_control.py
@@ -15,6 +15,7 @@
 
 #!/usr/bin/env python3
 import time
+import gc
 
 import rclpy
 from rclpy.node import Node
@@ -533,6 +534,13 @@ class InteractiveControlsNode(Node):
 
         # no duplicate transform now, we already have pose_world
         self.sync_endeffector_world_marker_pose(pose_world, self.uvms_backend.world_frame)
+
+    def destroy_node(self):
+        if getattr(self, "uvms_backend", None) is not None:
+            self.uvms_backend.close()
+            self.uvms_backend = None
+        gc.collect()
+        return super().destroy_node()
 
 def main(args=None):
     rclpy.init(args=args)

--- a/simlab/joystick_control.py
+++ b/simlab/joystick_control.py
@@ -16,6 +16,7 @@
 #!/usr/bin/env python3
 import rclpy
 from rclpy.node import Node
+from simlab.shutdown import install_signal_shutdown_handler, shutdown_node, spin_until_shutdown
 from simlab.robot import Robot, ControlMode
 import tf2_ros
 from geometry_msgs.msg import PoseStamped
@@ -83,14 +84,12 @@ class PS4TeleopNode(Node):
 
 def main(args=None):
     rclpy.init(args=args)
+    install_signal_shutdown_handler()
     teleop_node = PS4TeleopNode()
     try:
-        rclpy.spin(teleop_node)
-    except KeyboardInterrupt:
-        teleop_node.get_logger().info('PS4 Teleop node stopped by KeyboardInterrupt.')
+        spin_until_shutdown(teleop_node)
     finally:
-        teleop_node.destroy_node()
-        rclpy.shutdown()
+        shutdown_node(teleop_node)
 
 
 if __name__ == '__main__':

--- a/simlab/planner_action_server.py
+++ b/simlab/planner_action_server.py
@@ -9,6 +9,7 @@ from rclpy.executors import MultiThreadedExecutor
 import tf2_ros
 from simlab.fcl_checker import FCLWorld
 from simlab.se3_ompl_planner import OmplPlanner
+from simlab.shutdown import install_signal_shutdown_handler, spin_until_shutdown
 
 class PlannerActionServer(Node):
 
@@ -239,15 +240,25 @@ class PlannerActionServer(Node):
 
 def main(args=None):
     rclpy.init(args=args)
+    install_signal_shutdown_handler()
     planner_action_server = PlannerActionServer()
 
     # Use a MultiThreadedExecutor to enable processing goals concurrently
     executor = MultiThreadedExecutor()
 
-    rclpy.spin(planner_action_server, executor=executor)
-
-    planner_action_server.destroy()
-    rclpy.shutdown()
+    try:
+        spin_until_shutdown(planner_action_server, executor=executor)
+    finally:
+        executor.shutdown()
+        try:
+            planner_action_server.destroy_node()
+        except (KeyboardInterrupt, Exception):
+            pass
+        if rclpy.ok():
+            try:
+                rclpy.shutdown()
+            except Exception:
+                pass
 
 if __name__ == '__main__':
     main()

--- a/simlab/robot.py
+++ b/simlab/robot.py
@@ -1747,6 +1747,18 @@ class Robot(Base):
         # publish zeros once immediately
         self.publish_commands([0.0]*6, [0.0]*5)
 
+    def close(self) -> None:
+        self._accept_planner_results = False
+        if self.vehicle_cart_traj is not None:
+            self.vehicle_cart_traj.close()
+            self.vehicle_cart_traj = None
+        if getattr(self, "ps4_controller", None) is not None:
+            try:
+                self.ps4_controller.running = False
+            except Exception:
+                pass
+        self.ps4_controller = None
+
     def reset_simulation(self) -> None:
         self.sim_reset_hold = True
         self._reset_local_command_state()

--- a/simlab/shutdown.py
+++ b/simlab/shutdown.py
@@ -1,0 +1,86 @@
+import signal
+import sys
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+
+
+_SHUTDOWN_REQUESTED = False
+
+
+class _ShutdownStderrFilter:
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def write(self, text):
+        if (
+            _SHUTDOWN_REQUESTED
+            and "The following exception was never retrieved: cannot use Destroyable because destruction was requested" in text
+        ):
+            return len(text)
+        return self._wrapped.write(text)
+
+    def flush(self):
+        return self._wrapped.flush()
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+def _mark_shutdown_requested():
+    global _SHUTDOWN_REQUESTED
+    _SHUTDOWN_REQUESTED = True
+    if not isinstance(sys.stderr, _ShutdownStderrFilter):
+        sys.stderr = _ShutdownStderrFilter(sys.stderr)
+
+
+def install_signal_shutdown_handler():
+    def _request_shutdown(signum, frame):
+        _mark_shutdown_requested()
+        try:
+            rclpy.try_shutdown()
+        except AttributeError:
+            if rclpy.ok():
+                rclpy.shutdown()
+        except Exception:
+            pass
+
+    signal.signal(signal.SIGINT, _request_shutdown)
+    signal.signal(signal.SIGTERM, _request_shutdown)
+
+
+def spin_until_shutdown(node, executor=None):
+    try:
+        if executor is None:
+            rclpy.spin(node)
+        else:
+            rclpy.spin(node, executor=executor)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        _mark_shutdown_requested()
+        pass
+    except Exception:
+        if rclpy.ok():
+            raise
+        _mark_shutdown_requested()
+
+
+def shutdown_node(node=None, executor=None):
+    if not rclpy.ok():
+        _mark_shutdown_requested()
+    if executor is not None:
+        try:
+            executor.shutdown()
+        except (KeyboardInterrupt, ExternalShutdownException):
+            pass
+    if node is not None:
+        try:
+            node.destroy_node()
+        except (KeyboardInterrupt, ExternalShutdownException):
+            pass
+        except Exception:
+            pass
+    if rclpy.ok():
+        try:
+            rclpy.shutdown()
+        except Exception:
+            pass

--- a/simlab/use_mocap.py
+++ b/simlab/use_mocap.py
@@ -13,6 +13,7 @@ import numpy as np
 import tf2_ros
 from tf2_ros import TransformException
 from geometry_msgs.msg import TransformStamped
+from simlab.shutdown import install_signal_shutdown_handler, shutdown_node, spin_until_shutdown
 
 def apply_transform(ps_in: PoseStamped, ts: TransformStamped, target_frame: str) -> PoseStamped:
     # ts gives a transform that converts data in source into target
@@ -136,7 +137,7 @@ class MocapPathBuilder(Node):
 
         # TF2 buffer and listener
         self.tf_buffer = tf2_ros.Buffer(cache_time=Duration(seconds=10.0))
-        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self, spin_thread=True)
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
 
     def cb_rigid_bodies(self, msg: RigidBodies):
         if not msg.rigidbodies:
@@ -204,13 +205,12 @@ class MocapPathBuilder(Node):
         
 def main():
     rclpy.init()
+    install_signal_shutdown_handler()
     node = MocapPathBuilder()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
-        pass
-    node.destroy_node()
-    rclpy.shutdown()
+        spin_until_shutdown(node)
+    finally:
+        shutdown_node(node)
 
 
 if __name__ == '__main__':

--- a/simlab/uvms_backend.py
+++ b/simlab/uvms_backend.py
@@ -152,6 +152,12 @@ class UVMSBackendCore:
         self.initialise_target_Poses()
         self.set_robot_selected(self.robots[0].k_robot)
 
+    def close(self) -> None:
+        for robot in self.robots:
+            robot.close()
+        self.robots.clear()
+        self.robot_selected = None
+
     def publish_fcl_environment_aabb_callback(self):
         stamp_now = self.node.get_clock().now().to_msg()
         min_marker, max_marker = backend_utils.visualize_min_max_coords(self.fcl_world.min_coords,

--- a/simlab/voxel_viz.py
+++ b/simlab/voxel_viz.py
@@ -18,6 +18,7 @@ import os
 import numpy as np
 import rclpy
 from rclpy.node import Node
+from simlab.shutdown import install_signal_shutdown_handler, shutdown_node, spin_until_shutdown
 from sensor_msgs.msg import PointCloud2
 from std_msgs.msg import String
 import trimesh
@@ -90,9 +91,15 @@ class VoxelVizNode(Node):
         self.timer = self.create_timer(0.1, self.tick)
 
     def publish_overlay_text_callback(self) -> None:
+        if not rclpy.ok():
+            return
         str_msg = String()
         str_msg.data = f"© {datetime.now().year} Louisiana State University. Research use."
-        self.overlay_text_publisher.publish(str_msg)
+        try:
+            self.overlay_text_publisher.publish(str_msg)
+        except Exception:
+            if rclpy.ok():
+                raise
 
 
     def tick(self):
@@ -101,6 +108,8 @@ class VoxelVizNode(Node):
         1. Publish point cloud of voxel centers to RViz for geometric sanity check.
         2. Placeholder for OccupancyGrid projection from octree later.
         """
+        if not rclpy.ok():
+            return
         # Publish voxel centers as PointCloud2
         if self.centers is not None and self.centers.shape[0] > 0:
             cloud_msg = points_to_cloud2(
@@ -108,7 +117,11 @@ class VoxelVizNode(Node):
                 frame_id="world_bottom",
                 stamp=self.get_clock().now().to_msg()
             )
-            self.cloud_pub.publish(cloud_msg)
+            try:
+                self.cloud_pub.publish(cloud_msg)
+            except Exception:
+                if rclpy.ok():
+                    raise
 
 
     def get_cache_path(self, voxel_size: float):
@@ -177,9 +190,12 @@ class VoxelVizNode(Node):
 
 def main():
     rclpy.init()
+    install_signal_shutdown_handler()
     node = VoxelVizNode()
-    rclpy.spin(node)
-    rclpy.shutdown()
+    try:
+        spin_until_shutdown(node)
+    finally:
+        shutdown_node(node)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add a shared shutdown helper for simlab Python nodes so SIGINT/SIGTERM requests rclpy shutdown instead of throwing `KeyboardInterrupt` through active callbacks.
- Update launched simlab nodes to destroy nodes and executors only when the context is still valid.
- Guard voxel/contact publishers during shutdown so publish attempts after context invalidation do not print tracebacks.
- Stop using a separate TF listener spin thread in the mocap path publisher.
- Explicitly release Ruckig/nanobind trajectory objects from the interactive backend before node destruction.

## Why

Ctrl-C was interrupting Python callbacks, TF listener threads, and action-server futures while ROS launch was already shutting down the graph. That produced noisy `KeyboardInterrupt`, `ExternalShutdownException`, and `rcl_shutdown already called` tracebacks even when the nodes were otherwise shutting down normally.

After those tracebacks were cleaned up, the remaining interactive-controller noise was Ruckig's nanobind leak checker reporting live `Ruckig`, `InputParameter`, and `OutputParameter` objects at interpreter exit. Those objects are now released through the backend/robot cleanup path before the ROS node is destroyed.

## Validation

- `python3 -m py_compile simlab/shutdown.py simlab/voxel_viz.py simlab/env_obstacles.py simlab/collision_contact.py simlab/planner_action_server.py simlab/use_mocap.py simlab/interactive_control.py simlab/joystick_control.py`
- `python3 -m py_compile simlab/cartesian_ruckig.py simlab/robot.py simlab/uvms_backend.py simlab/interactive_control.py simlab/shutdown.py`
- `colcon build --packages-select simlab --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- Ran simulated multi-interface interactive launch with camera and forced SIGINT; simlab Python stack traces and the Ruckig/nanobind leak report were gone.

Remaining shutdown messages are ROS launch SIGINT process-status lines and `controller_manager.pal_statistics` from ROS 2 controller manager.