### PR TITLE
Fix vehicle yaw command continuity

### DIFF
--- a/simlab/controllers/pid.py
+++ b/simlab/controllers/pid.py
@@ -24,6 +24,7 @@ class LowLevelPidController(ControllerTemplate):
         self.uv_pid_controller = ca.Function.load(uv_pid_controller_path)
         self.arm_params, self.vehicle_params = select_robot_params(self.robot_prefix)
         self.vehicle_pid_i_buffer = np.zeros(6, dtype=float)
+        self._last_vehicle_pid_target_yaw = None
         self.vehicle_i_limit = self.vehicle_params.i_limit
         self.vehicle_model_params = self.vehicle_params.model_params
         self.kp = self.vehicle_params.pid_kp
@@ -68,7 +69,22 @@ class LowLevelPidController(ControllerTemplate):
 
     def reset_controller_state(self) -> None:
         self.vehicle_pid_i_buffer = np.zeros(6, dtype=float)
+        self._last_vehicle_pid_target_yaw = None
         self.arm_pid_i_buffer = np.zeros(self.arm_dof + 1, dtype=float)
+
+    @staticmethod
+    def _unwrap_yaw_to_reference(desired_yaw: float, reference_yaw: float) -> float:
+        yaw_error = float(desired_yaw) - float(reference_yaw)
+        return float(reference_yaw) + (yaw_error + np.pi) % (2.0 * np.pi) - np.pi
+
+    def _normalize_target_yaw_for_pid(self, state: np.ndarray, target_pos: np.ndarray) -> np.ndarray:
+        target = np.asarray(target_pos, dtype=float).copy()
+        reference_yaw = self._last_vehicle_pid_target_yaw
+        if reference_yaw is None:
+            reference_yaw = float(state[5])
+        target[5] = self._unwrap_yaw_to_reference(target[5], reference_yaw)
+        self._last_vehicle_pid_target_yaw = float(target[5])
+        return target
 
     def vehicle_controller(
         self,
@@ -80,6 +96,7 @@ class LowLevelPidController(ControllerTemplate):
     ) -> np.ndarray:
         state = self.vector(state, 12, "state")
         target_pos = self.vector(target_pos, 6, "target_pos")
+        target_pos = self._normalize_target_yaw_for_pid(state, target_pos)
         target_vel = self.vector(target_vel, 6, "target_vel")
 
         buf = np.zeros(6, dtype=float)

--- a/simlab/robot.py
+++ b/simlab/robot.py
@@ -473,6 +473,8 @@ class Robot(Base):
         self.menu_handle = None
         self.final_goal_map_ned_6 = None
         self.yaw_blend_factor = 0.0
+        self._last_vehicle_cmd_yaw = None
+        self._last_vehicle_cmd_yaw_step = 0.0
         self.tf_buffer = tf_buffer
         self.task_based_controller = False
 
@@ -679,6 +681,8 @@ class Robot(Base):
         self.max_traj_vel = np.array([0.15, 0.15, 0.10], dtype=float)
         self.max_traj_acc = np.array([0.1, 0.1, 0.1], dtype=float)
         self.max_traj_jerk = np.array([0.05, 0.05, 0.05], dtype=float)
+        self.max_yaw_command_rate = 1.0
+        self.yaw_command_dt = 1.0 / 60.0
 
         self.node_name = node.get_name()
         # Search for joystick device in /dev/input
@@ -759,6 +763,7 @@ class Robot(Base):
 
     def set_controller(self, name: str, activate: bool = True) -> bool:
         previous_controller = self.active_controller_instance()
+        self.reset_vehicle_command_yaw_memory()
         if activate and self.control_mode == ControlMode.REPLAY_SETTLE and name != "CmdReplay":
             self.cancel_replay_settle(mark_failed=True)
             self.control_mode = ControlMode.PLANNER
@@ -1534,6 +1539,30 @@ class Robot(Base):
         adjusted_desired_yaw = current_yaw + angle_diff
         return adjusted_desired_yaw
 
+    def reset_vehicle_command_yaw_memory(self) -> None:
+        self._last_vehicle_cmd_yaw = None
+        self._last_vehicle_cmd_yaw_step = 0.0
+
+    def continuous_vehicle_command_yaw(
+        self,
+        desired_yaw: float,
+        fallback_yaw: float | None = None,
+        max_step: float | None = None,
+    ) -> float:
+        reference_yaw = self._last_vehicle_cmd_yaw
+        if reference_yaw is None:
+            reference_yaw = float(self.ned_pose[5] if fallback_yaw is None else fallback_yaw)
+        command_yaw = self.normalize_angle(float(desired_yaw), float(reference_yaw))
+        delta = command_yaw - float(reference_yaw)
+        if max_step is not None and max_step > 0.0:
+            if abs(delta) > (0.5 * np.pi) and abs(self._last_vehicle_cmd_yaw_step) > 1e-12:
+                delta = np.copysign(abs(delta), self._last_vehicle_cmd_yaw_step)
+            delta = np.clip(delta, -float(max_step), float(max_step))
+            command_yaw = float(reference_yaw) + float(delta)
+        self._last_vehicle_cmd_yaw = command_yaw
+        self._last_vehicle_cmd_yaw_step = float(delta)
+        return command_yaw
+
     def publish_vehicle_and_arm(
         self,
         wrench_body_6: Sequence[float],
@@ -1722,6 +1751,7 @@ class Robot(Base):
             self._preserve_active_plan_on_failure = False
 
     def _start_vehicle_cartesian_ruckig(self, start_xyz, start_quat_wxyz, path_xyz: np.ndarray) -> None:
+        self.reset_vehicle_command_yaw_memory()
         self.vehicle_cart_traj.start_from_path(
             current_position=list(start_xyz),
             path_xyz=path_xyz,
@@ -1924,7 +1954,13 @@ class Robot(Base):
                 # Blend on the unwrapped shortest yaw arc. Directly averaging
                 # angles near +/-pi can command a full turn through zero.
                 target_yaw = self.normalize_angle(float(rpy_cmd_ned[2]), adjusted_yaw)
-                rpy_cmd_ned[2] = adjusted_yaw + self.yaw_blend_factor * (target_yaw - adjusted_yaw)
+                blended_yaw = adjusted_yaw + self.yaw_blend_factor * (target_yaw - adjusted_yaw)
+                max_yaw_step = float(self.max_yaw_command_rate) * float(self.yaw_command_dt)
+                rpy_cmd_ned[2] = self.continuous_vehicle_command_yaw(
+                    blended_yaw,
+                    fallback_yaw=self.ned_pose[5],
+                    max_step=max_yaw_step,
+                )
 
                 cmd_J_UV = self.vehicle_J(rpy_cmd_ned).full()
                 self.node.get_logger().debug(f"v_cmd_ned {tw6_map_ned} : active.")
@@ -2117,6 +2153,7 @@ class Robot(Base):
     def set_control_mode(self, mode: ControlMode):
         if mode == self.control_mode:
             return
+        self.reset_vehicle_command_yaw_memory()
         if self.control_mode == ControlMode.REPLAY and mode != ControlMode.REPLAY:
             self._stop_replay_session_recording("mode_exit")
         if mode == ControlMode.PLANNER and self.control_mode == ControlMode.REPLAY_SETTLE:

--- a/test/test_vehicle_yaw_continuity.py
+++ b/test/test_vehicle_yaw_continuity.py
@@ -1,0 +1,76 @@
+import sys
+import types
+
+import numpy as np
+
+control_msgs_msg = sys.modules.get("control_msgs.msg")
+if control_msgs_msg is not None:
+    if not hasattr(control_msgs_msg, "DynamicInterfaceGroupValues"):
+        control_msgs_msg.DynamicInterfaceGroupValues = object
+    if not hasattr(control_msgs_msg, "DynamicJointState"):
+        control_msgs_msg.DynamicJointState = object
+    if not hasattr(control_msgs_msg, "InterfaceValue"):
+        control_msgs_msg.InterfaceValue = object
+
+simlab_msg = sys.modules.get("simlab.msg")
+if simlab_msg is None:
+    simlab_msg = types.ModuleType("simlab.msg")
+    sys.modules["simlab.msg"] = simlab_msg
+if not hasattr(simlab_msg, "ControllerPerformance"):
+    simlab_msg.ControllerPerformance = object
+if not hasattr(simlab_msg, "ReferenceTargets"):
+    simlab_msg.ReferenceTargets = object
+
+simlab_srv = sys.modules.get("simlab.srv")
+if simlab_srv is None:
+    simlab_srv = types.ModuleType("simlab.srv")
+    sys.modules["simlab.srv"] = simlab_srv
+simlab_srv.ResetSimVehicle = object
+simlab_srv.ResetSimManipulator = object
+simlab_srv.ResetSimRobotState = object
+
+simlab_action = sys.modules.get("simlab.action")
+if simlab_action is None:
+    simlab_action = types.ModuleType("simlab.action")
+    sys.modules["simlab.action"] = simlab_action
+simlab_action.PlanVehicle = object
+
+from simlab.controllers.pid import LowLevelPidController
+from simlab.robot import Robot
+
+
+def test_vehicle_command_yaw_unwraps_against_previous_command():
+    robot = Robot.__new__(Robot)
+    robot.ned_pose = [0.0, 0.0, 0.0, 0.0, 0.0, -2.10]
+    robot._last_vehicle_cmd_yaw = None
+    robot._last_vehicle_cmd_yaw_step = 0.0
+
+    max_step = 0.02
+    first = robot.continuous_vehicle_command_yaw(0.852, fallback_yaw=robot.ned_pose[5], max_step=max_step)
+    second = robot.continuous_vehicle_command_yaw(-5.046, fallback_yaw=robot.ned_pose[5], max_step=max_step)
+    third = robot.continuous_vehicle_command_yaw(0.877, fallback_yaw=robot.ned_pose[5], max_step=max_step)
+
+    assert abs(first - robot.ned_pose[5]) <= max_step + 1e-12
+    assert abs(second - first) <= max_step + 1e-12
+    assert abs(third - second) <= max_step + 1e-12
+    assert first > robot.ned_pose[5]
+    assert second > first
+    assert third > second
+
+
+def test_pid_yaw_guard_preserves_target_continuity_across_equivalent_branches():
+    controller = object.__new__(LowLevelPidController)
+    controller._last_vehicle_pid_target_yaw = None
+    state = np.zeros(12)
+    state[5] = -2.107
+    positive_branch = np.zeros(6)
+    negative_branch = np.zeros(6)
+    positive_branch[5] = 0.852
+    negative_branch[5] = -5.046
+
+    first = controller._normalize_target_yaw_for_pid(state, positive_branch)
+    second = controller._normalize_target_yaw_for_pid(state, negative_branch)
+
+    assert abs((first[5] - state[5]) - 2.959) < 1e-6
+    assert abs(second[5] - first[5]) < 0.5
+    assert second[5] > 0.0


### PR DESCRIPTION
keep planner-generated vehicle yaw commands continuous across angle wrap boundaries
unwrap PID target yaw against the previous controller target
add focused regression coverage for yaw branch continuity