### PR TITLE
Move yaw reference continuity out of PID

### DIFF
--- a/simlab/controllers/pid.py
+++ b/simlab/controllers/pid.py
@@ -24,7 +24,6 @@ class LowLevelPidController(ControllerTemplate):
         self.uv_pid_controller = ca.Function.load(uv_pid_controller_path)
         self.arm_params, self.vehicle_params = select_robot_params(self.robot_prefix)
         self.vehicle_pid_i_buffer = np.zeros(6, dtype=float)
-        self._last_vehicle_pid_target_yaw = None
         self.vehicle_i_limit = self.vehicle_params.i_limit
         self.vehicle_model_params = self.vehicle_params.model_params
         self.kp = self.vehicle_params.pid_kp
@@ -69,22 +68,8 @@ class LowLevelPidController(ControllerTemplate):
 
     def reset_controller_state(self) -> None:
         self.vehicle_pid_i_buffer = np.zeros(6, dtype=float)
-        self._last_vehicle_pid_target_yaw = None
         self.arm_pid_i_buffer = np.zeros(self.arm_dof + 1, dtype=float)
 
-    @staticmethod
-    def _unwrap_yaw_to_reference(desired_yaw: float, reference_yaw: float) -> float:
-        yaw_error = float(desired_yaw) - float(reference_yaw)
-        return float(reference_yaw) + (yaw_error + np.pi) % (2.0 * np.pi) - np.pi
-
-    def _normalize_target_yaw_for_pid(self, state: np.ndarray, target_pos: np.ndarray) -> np.ndarray:
-        target = np.asarray(target_pos, dtype=float).copy()
-        reference_yaw = self._last_vehicle_pid_target_yaw
-        if reference_yaw is None:
-            reference_yaw = float(state[5])
-        target[5] = self._unwrap_yaw_to_reference(target[5], reference_yaw)
-        self._last_vehicle_pid_target_yaw = float(target[5])
-        return target
 
     def vehicle_controller(
         self,
@@ -96,7 +81,6 @@ class LowLevelPidController(ControllerTemplate):
     ) -> np.ndarray:
         state = self.vector(state, 12, "state")
         target_pos = self.vector(target_pos, 6, "target_pos")
-        target_pos = self._normalize_target_yaw_for_pid(state, target_pos)
         target_vel = self.vector(target_vel, 6, "target_vel")
 
         buf = np.zeros(6, dtype=float)

--- a/simlab/robot.py
+++ b/simlab/robot.py
@@ -1566,6 +1566,22 @@ class Robot(Base):
         self._last_vehicle_cmd_yaw_step = float(delta)
         return command_yaw
 
+    def continuous_vehicle_reference_pose(
+        self,
+        target_pose: Sequence[float],
+        fallback_yaw: float | None = None,
+        max_step: float | None = None,
+    ) -> np.ndarray:
+        target = np.asarray(target_pose, dtype=float).copy()
+        if target.shape[0] < 6:
+            raise ValueError("vehicle target pose must contain 6 values")
+        target[5] = self.continuous_vehicle_command_yaw(
+            float(target[5]),
+            fallback_yaw=fallback_yaw,
+            max_step=max_step,
+        )
+        return target
+
     def publish_vehicle_and_arm(
         self,
         wrench_body_6: Sequence[float],
@@ -2947,7 +2963,11 @@ class Robot(Base):
             self.arm.ddq_command = [0.0] * 4
 
             veh_state_vec = np.array(list(state["pose"]) + list(state["body_vel"]), dtype=float)
-            target_ned_pose = np.asarray(self.pose_command, dtype=float)
+            target_ned_pose = self.continuous_vehicle_reference_pose(
+                self.pose_command,
+                fallback_yaw=state["pose"][5],
+            )
+            self.pose_command = target_ned_pose.tolist()
             target_body_vel = np.asarray(self.body_vel_command, dtype=float)
             target_body_acc = np.asarray(self.body_acc_command, dtype=float)
             q_ref = np.asarray(arm_target, dtype=float).tolist()
@@ -3035,17 +3055,25 @@ class Robot(Base):
                 cmd_body_wrench = active_controller.vehicle_command_at(sample_index)
             elif vehicle_mode == "track_reference" and feedback_spec is not None:
                 target_pos, target_vel, target_acc = active_controller.vehicle_reference_at(sample_index)
+                target_pos = self.continuous_vehicle_reference_pose(
+                    target_pos,
+                    fallback_yaw=state["pose"][5],
+                )
                 cmd_body_wrench = feedback_spec.vehicle_fn(
                     state=veh_state_vec,
-                    target_pos=np.asarray(target_pos, dtype=float),
+                    target_pos=target_pos,
                     target_vel=np.asarray(target_vel, dtype=float),
                     target_acc=np.asarray(target_acc, dtype=float),
                     dt=state["dt"],
                 )
             elif vehicle_mode == "hold_initial" and feedback_spec is not None:
+                target_pos = self.continuous_vehicle_reference_pose(
+                    active_controller.initial_vehicle_pose(),
+                    fallback_yaw=state["pose"][5],
+                )
                 cmd_body_wrench = feedback_spec.vehicle_fn(
                     state=veh_state_vec,
-                    target_pos=np.asarray(active_controller.initial_vehicle_pose(), dtype=float),
+                    target_pos=target_pos,
                     target_vel=np.zeros(6, dtype=float),
                     target_acc=np.zeros(6, dtype=float),
                     dt=state["dt"],

--- a/test/test_vehicle_yaw_continuity.py
+++ b/test/test_vehicle_yaw_continuity.py
@@ -35,7 +35,6 @@ if simlab_action is None:
     sys.modules["simlab.action"] = simlab_action
 simlab_action.PlanVehicle = object
 
-from simlab.controllers.pid import LowLevelPidController
 from simlab.robot import Robot
 
 
@@ -58,19 +57,20 @@ def test_vehicle_command_yaw_unwraps_against_previous_command():
     assert third > second
 
 
-def test_pid_yaw_guard_preserves_target_continuity_across_equivalent_branches():
-    controller = object.__new__(LowLevelPidController)
-    controller._last_vehicle_pid_target_yaw = None
-    state = np.zeros(12)
-    state[5] = -2.107
+def test_vehicle_reference_pose_unwraps_before_controller_dispatch():
+    robot = Robot.__new__(Robot)
+    robot.ned_pose = [0.0, 0.0, 0.0, 0.0, 0.0, -2.107]
+    robot._last_vehicle_cmd_yaw = None
+    robot._last_vehicle_cmd_yaw_step = 0.0
     positive_branch = np.zeros(6)
     negative_branch = np.zeros(6)
     positive_branch[5] = 0.852
     negative_branch[5] = -5.046
 
-    first = controller._normalize_target_yaw_for_pid(state, positive_branch)
-    second = controller._normalize_target_yaw_for_pid(state, negative_branch)
+    first = robot.continuous_vehicle_reference_pose(positive_branch, fallback_yaw=robot.ned_pose[5])
+    second = robot.continuous_vehicle_reference_pose(negative_branch, fallback_yaw=robot.ned_pose[5])
 
-    assert abs((first[5] - state[5]) - 2.959) < 1e-6
+    assert abs((first[5] - robot.ned_pose[5]) - 2.959) < 1e-6
     assert abs(second[5] - first[5]) < 0.5
     assert second[5] > 0.0
+    assert negative_branch[5] == -5.046


### PR DESCRIPTION
- remove stateful yaw target normalization from the PID controller
- normalize continuous vehicle yaw references in the robot/controller dispatch layer
- keep replay `track_reference`, replay hold, and planner settle references controller-agnostic
- update yaw continuity tests to cover the robot-level reference contract