### PR TITLE
Fix premature trajectory planner exit during interactive rotation

### DIFF
--- a/simlab/cartesian_ruckig.py
+++ b/simlab/cartesian_ruckig.py
@@ -33,6 +33,7 @@ class VehicleCartesianRuckig:
         self.out = OutputParameter(dofs, max_waypoints)
         self.active = False
         self.yaw_finish_threshold = 0.95
+        self.yaw_error_threshold = 0.05
         self.last_result = None
         self.last_yaw_blend_factor = 0.0
 
@@ -106,11 +107,17 @@ class VehicleCartesianRuckig:
                 f"duration {self.out.trajectory.duration:0.4f} s"
             )
 
-        if res == Result.Finished and yaw_blend_factor >= self.yaw_finish_threshold:
-            self.rclpy_node.get_logger().info("Ruckig trajectory finished")
-            self.active = False
+        # if res == Result.Finished and yaw_blend_factor >= self.yaw_finish_threshold:
+        #     self.rclpy_node.get_logger().info("Ruckig trajectory finished")
+        #     self.active = False
 
         return pos, vel, acc, res
+
+    def check_finished(self, yaw_blend_factor, yaw_error):
+        """Check if the trajectory is finished and if the yaw blend factor and yaw error is sufficient to consider it done."""
+        if self.last_result == Result.Finished and yaw_blend_factor < self.yaw_finish_threshold and abs(yaw_error) < self.yaw_error_threshold:
+            self.rclpy_node.get_logger().info("Ruckig trajectory finished")
+            self.active = False
 
     def close(self):
         self.active = False

--- a/simlab/cartesian_ruckig.py
+++ b/simlab/cartesian_ruckig.py
@@ -115,7 +115,7 @@ class VehicleCartesianRuckig:
 
     def check_finished(self, yaw_blend_factor, yaw_error):
         """Check if the trajectory is finished and if the yaw blend factor and yaw error is sufficient to consider it done."""
-        if self.last_result == Result.Finished and yaw_blend_factor < self.yaw_finish_threshold and abs(yaw_error) < self.yaw_error_threshold:
+        if self.last_result == Result.Finished and yaw_blend_factor >= self.yaw_finish_threshold and abs(yaw_error) < self.yaw_error_threshold:
             self.rclpy_node.get_logger().info("Ruckig trajectory finished")
             self.active = False
 

--- a/simlab/robot.py
+++ b/simlab/robot.py
@@ -1986,6 +1986,10 @@ class Robot(Base):
                     fallback_yaw=self.ned_pose[5],
                     max_step=max_yaw_step,
                 )
+                yaw_error = self.ned_pose[5] - self.normalize_angle(float(target_yaw), float(self.ned_pose[5]))
+                self.vehicle_cart_traj.check_finished(goal_xyz_error, yaw_error)
+     #            self.node.get_logger().info(
+					# f"goal_xyz_error={goal_xyz_error:.3f}, yaw_error={yaw_error:.3f}, ")
 
                 cmd_J_UV = self.vehicle_J(rpy_cmd_ned).full()
                 self.node.get_logger().debug(f"v_cmd_ned {tw6_map_ned} : active.")

--- a/simlab/robot.py
+++ b/simlab/robot.py
@@ -1987,7 +1987,7 @@ class Robot(Base):
                     max_step=max_yaw_step,
                 )
                 yaw_error = self.ned_pose[5] - self.normalize_angle(float(target_yaw), float(self.ned_pose[5]))
-                self.vehicle_cart_traj.check_finished(goal_xyz_error, yaw_error)
+                self.vehicle_cart_traj.check_finished(self.yaw_blend_factor, yaw_error)
      #            self.node.get_logger().info(
 					# f"goal_xyz_error={goal_xyz_error:.3f}, yaw_error={yaw_error:.3f}, ")
 


### PR DESCRIPTION
## Summary
Fixes a logic issue in interactive mode where the planner exits prematurely when commanding the vehicle to only yaw. 

## Cause of the Bug
The trajectory planner previously only checked the linear position error to determine completion. Because it ignored angular orientation error, it would exit after providing a very small initial yaw target, leaving the vehicle short of its actual yaw goal.

## Solution
Modified the exit criteria to check both linear and angular thresholds. The vehicle must now fall within the defined yaw threshold before the planner will successfully terminate.

## How to Test
1. Put the vehicle into **interactive mode**.
2. Issue a command containing **only a yaw adjustment**.
3. Verify that the planner remains active until the vehicle reaches the target heading within the designated threshold.
